### PR TITLE
Refactor plugin config for Lolcommits v0.10.0

### DIFF
--- a/lib/lolcommits/dotcom/version.rb
+++ b/lib/lolcommits/dotcom/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Dotcom
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lib/lolcommits/plugin/dotcom.rb
+++ b/lib/lolcommits/plugin/dotcom.rb
@@ -16,15 +16,6 @@ module Lolcommits
       end
 
       ##
-      # Returns the name of the plugin to identify the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'dotcom'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Uploading happens when a new capture is ready.
       #
@@ -32,16 +23,6 @@ module Lolcommits
       #
       def self.runner_order
         [:capture_ready]
-      end
-
-      ##
-      # Returns true if the plugin has been configured.
-      #
-      # @return [Boolean] true/false indicating if plugin is configured
-      #
-      def configured?
-        !configuration.values.empty? &&
-          configuration.values.all? { |value| !value.nil? }
       end
 
       ##
@@ -84,13 +65,13 @@ module Lolcommits
           {
             git_commit: {
               sha: runner.sha,
-              repo_external_id: configuration['repo_id'],
+              repo_external_id: configuration[:repo_id],
               image: File.open(runner.main_image),
               raw: File.open(runner.snapshot_loc)
             },
-            key: configuration['api_key'],
+            key: configuration[:api_key],
             t: t,
-            token: Digest::SHA1.hexdigest(configuration['api_secret'] + t)
+            token: Digest::SHA1.hexdigest(configuration[:api_secret] + t)
           }
         )
       rescue => e
@@ -107,7 +88,7 @@ module Lolcommits
       # @return [Array] the option names
       #
       def plugin_options
-        %w(api_key api_secret repo_id)
+        [:api_key, :api_secret, :repo_id]
       end
     end
   end

--- a/lolcommits-dotcom.gemspec
+++ b/lolcommits-dotcom.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* bump gem version (for new plugin release)